### PR TITLE
Feature addition: permissions option for seeing only own topics in listing

### DIFF
--- a/library.js
+++ b/library.js
@@ -118,22 +118,22 @@ plugin.filterTids = function(data, callback) {
 };
 
 plugin.filterCategory = function(data, callback) {
-	if (plugin.config.ownOnly) {
+	if (plugin.config.ownOnly=='on') {
 		User.isAdministrator(data.uid, function(err, isAdmin) {
-		  if (!isAdmin) {
-	      var filtered = [];
-	      if (data.topics && data.topics.length) {
-		      data.topics.forEach( function(topic) {
-		        if (parseInt(topic.cid, 10) !== parseInt(plugin.config.cid, 10) || parseInt(topic.uid, 10) === parseInt(data.uid)) {
-		          filtered.push(topic);
-		        }
-		      });
-	      }
-	      callback(null, {topics:filtered,uid:data.uid});
-		  } else {
-	      callback(null, data);
-		  }
-	  });
+			if (!isAdmin) {
+				var filtered = [];
+				if (data.topics && data.topics.length) {
+					data.topics.forEach( function(topic) {
+						if (parseInt(topic.cid, 10) !== parseInt(plugin.config.cid, 10) || parseInt(topic.uid, 10) === parseInt(data.uid)) {
+							filtered.push(topic);
+						}
+					});
+				}
+				callback(null, {topics:filtered,uid:data.uid});
+			} else {
+				callback(null, data);
+			}
+		});
 	} else {
 		callback(null, data);
 	}

--- a/library.js
+++ b/library.js
@@ -15,7 +15,7 @@ plugin.init = function(params, callback) {
 	var app = params.router,
 		middleware = params.middleware,
 		controllers = params.controllers;
-		
+
 	app.get('/admin/plugins/support-forum', middleware.admin.buildHeader, renderAdmin);
 	app.get('/api/admin/plugins/support-forum', renderAdmin);
 
@@ -52,7 +52,7 @@ plugin.restrict.topic = function(privileges, callback) {
 			winston.verbose('[plugins/support-forum] tid ' + privileges.tid + ' (author uid: ' + data.topicObj.uid + ') access attempt by uid ' + privileges.uid + ' blocked.');
 			privileges.read = false;
 		}
-		
+
 		callback(null, privileges);
 	});
 };
@@ -115,6 +115,28 @@ plugin.filterTids = function(data, callback) {
 			callback(null, data);
 		}
 	});
+};
+
+plugin.filterCategory = function(data, callback) {
+	if (plugin.config.ownOnly) {
+		User.isAdministrator(data.uid, function(err, isAdmin) {
+		  if (!isAdmin) {
+	      var filtered = [];
+	      if (data.topics && data.topics.length) {
+		      data.topics.forEach( function(topic) {
+		        if (parseInt(topic.cid, 10) !== parseInt(plugin.config.cid, 10) || parseInt(topic.uid, 10) === parseInt(data.uid)) {
+		          filtered.push(topic);
+		        }
+		      });
+	      }
+	      callback(null, {topics:filtered,uid:data.uid});
+		  } else {
+	      callback(null, data);
+		  }
+	  });
+	} else {
+		callback(null, data);
+	}
 };
 
 /* Admin stuff */

--- a/plugin.json
+++ b/plugin.json
@@ -11,6 +11,7 @@
 		{ "hook": "filter:privileges.topics.filter", "method": "filterTids" },
 		{ "hook": "filter:privileges.posts.filter", "method": "filterPids" },
 		{ "hook": "filter:categories.recent", "method": "filterPids" },
+		{ "hook": "filter:category.topics.get", "method": "filterCategory" },
 		{ "hook": "static:app.load", "method": "init" },
 		{ "hook": "filter:admin.header.build", "method": "addAdminNavigation" }
 	],

--- a/static/templates/admin/plugins/support-forum.tpl
+++ b/static/templates/admin/plugins/support-forum.tpl
@@ -21,6 +21,9 @@
 							<input type="checkbox" name="ownOnly" id="ownOnly">
 							Non-admins see only their own topics
 						</label>
+						<p class="help-block">
+							If checked, users without administrative privileges will see only their own topics when in a support forum.
+						</p>
 					</div>
 				</form>
 			</div>

--- a/static/templates/admin/plugins/support-forum.tpl
+++ b/static/templates/admin/plugins/support-forum.tpl
@@ -16,6 +16,12 @@
 							Designating a forum as a support forum will restrict access to that category's topics to only admit admins and the original topic creator. Please ensure that you have also set the "# of Recent Replies" value to "0" in this category's settings.
 						</p>
 					</div>
+					<div class="form-group">
+						<label for="ownOnly">
+							<input type="checkbox" name="ownOnly" id="ownOnly">
+							Non-admins see only their own topics
+						</label>
+					</div>
 				</form>
 			</div>
 		</div>

--- a/static/templates/admin/plugins/support-forum.tpl
+++ b/static/templates/admin/plugins/support-forum.tpl
@@ -19,10 +19,10 @@
 					<div class="form-group">
 						<label for="ownOnly">
 							<input type="checkbox" name="ownOnly" id="ownOnly">
-							Non-admins see only their own topics
+							Non-admins see only their own topics listed
 						</label>
 						<p class="help-block">
-							If checked, users without administrative privileges will see only their own topics when in a support forum.
+							If checked, users without administrative privileges will see only their own topics listed in a support forum.
 						</p>
 					</div>
 				</form>


### PR DESCRIPTION
Related to discussion in https://github.com/julianlam/nodebb-plugin-support-forum/issues/3, this adds a setting for restricting non-admin users to see only their own topics listed within the support forum.