### PR TITLE
Block user follow notifications (closes https://github.com/julianlam/nodebb-plugin-support-forum/issues/2)

### DIFF
--- a/library.js
+++ b/library.js
@@ -35,8 +35,13 @@ plugin.blockNewTopicAlert = function (data, callback) {
 			async.apply(Topics.getTopicFields, data.notification.tid, ['cid']),
 			function (topicInfo, next) {
 				if (parseInt(topicInfo.cid, 10) === parseInt(plugin.config.cid, 10)) {
-					winston.verbose(`[plugins/support-forum] Notification (category:support - ${plugin.config.cid}) blocked`);
-					callback(null, false);
+					const { uids } = data;
+					Promise.all(uids.map(uid => User.isAdministrator(parseInt(uid, 10))))
+					.then((results) => {
+						data.uids = uids.filter((_v, index) => results[index])
+						winston.verbose(`[plugins/support-forum] Notification (category:support - cid: ${plugin.config.cid}) blocked for ${uids.length - data.uids.length} users not admin`);
+						callback(null, data);
+					});
 				} else {
 					callback(null, data); // not support forum category
 				}

--- a/library.js
+++ b/library.js
@@ -29,8 +29,44 @@ plugin.init = function(params, callback) {
 
 /* Meat */
 
-plugin.supportify = function(data, callback) {	// There are only two hard things in Computer Science: cache invalidation and naming things. -- Phil Karlton
-	User.isAdministrator(data.uid, function(err, isAdmin) {
+plugin.blockNewTopicAlert = function (data, callback) {
+	if (data.notification.type === 'new-topic') {
+		async.waterfall([
+			async.apply(Topics.getTopicFields, data.notification.tid, ['cid']),
+			function (topicInfo, next) {
+				if (parseInt(topicInfo.cid, 10) === parseInt(plugin.config.cid, 10)) {
+					winston.verbose(`[plugins/support-forum] Notification (category:support - ${plugin.config.cid}) blocked`);
+					callback(null, false);
+				} else {
+					callback(null, data); // not support forum category
+				}
+			}
+		]);
+	} else {
+		callback(null, data); // not new-topic type
+	}
+}
+
+plugin.blockNewTopicAlert = function (data, callback) {
+	if (data.notification.type === 'new-topic') {
+		async.waterfall([
+			async.apply(Topics.getTopicFields, data.notification.tid, ['cid']),
+			function (topicInfo, next) {
+				if (parseInt(topicInfo.cid, 10) === parseInt(plugin.config.cid, 10)) {
+					winston.verbose(`[plugins/support-forum] Notification (category:support - ${plugin.config.cid}) blocked`);
+					callback(null, false);
+				} else {
+					callback(null, data); // not support forum category
+				}
+			}
+		]);
+	} else {
+		callback(null, data); // not new-topic type
+	}
+}
+
+plugin.supportify = function (data, callback) {	// There are only two hard things in Computer Science: cache invalidation and naming things. -- Phil Karlton
+	User.isAdministrator(data.uid, function (err, isAdmin) {
 		if (!isAdmin && parseInt(data.cid, 10) === parseInt(plugin.config.cid, 10)) {
 			winston.verbose('[plugins/support-forum] Support forum accessed by uid ' + data.uid);
 			data.targetUid = data.uid;

--- a/plugin.json
+++ b/plugin.json
@@ -13,7 +13,8 @@
 		{ "hook": "filter:categories.recent", "method": "filterPids" },
 		{ "hook": "filter:category.topics.get", "method": "filterCategory" },
 		{ "hook": "static:app.load", "method": "init" },
-		{ "hook": "filter:admin.header.build", "method": "addAdminNavigation" }
+		{ "hook": "filter:admin.header.build", "method": "addAdminNavigation" },
+		{ "hook": "filter:notification.push", "method": "blockNewTopicAlert" }
 	],
 	"templates": "static/templates"
 }


### PR DESCRIPTION
See https://github.com/julianlam/nodebb-plugin-support-forum/issues/2.
Changes: Block alerts for new topics in the support category. Not blocking for admins.
(I just changed the order of the functions, so it seems like I changed a lot ... but I did not change except for the addition I wrote above).
@julianlam :)