### PR TITLE
Hide posts from the support category on the profile page

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -15,7 +15,8 @@
 		{ "hook": "filter:category.topics.get", "method": "filterCategory" },
 		{ "hook": "static:app.load", "method": "init" },
 		{ "hook": "filter:admin.header.build", "method": "addAdminNavigation" },
-		{ "hook": "filter:notification.push", "method": "blockUserFollowNotifications" }
+		{ "hook": "filter:notification.push", "method": "blockUserFollowNotifications" },
+		{ "hook": "filter:account/profile.build", "method": "filterProfile" }
 	],
 	"templates": "static/templates",
 	"scripts": [


### PR DESCRIPTION
Hi,
There is currently a bug in the plugin that can be seen on the user's profile page, in his recent/best posts section, also posts from the support category. This PR came to solve this.
(Not `https://forum.com/user/user-name/posts` already fixed by filterPids function, but` https://forum.com/user/user-name`).

>Thanks to @barisusakli for the name of the hook needed to make the repair!
https://community.nodebb.org/post/88399