### PR TITLE
feat: per-viewer support-category counts, filter RSS

### DIFF
--- a/library.js
+++ b/library.js
@@ -6,6 +6,7 @@ const User = require.main.require('./src/user');
 const Posts = require.main.require('./src/posts');
 const Topics = require.main.require('./src/topics');
 const Categories = require.main.require('./src/categories');
+const db = require.main.require('./src/database');
 const meta = require.main.require('./src/meta');
 const utils = require.main.require('./src/utils');
 
@@ -22,11 +23,11 @@ plugin.init = function (params, callback) {
 };
 
 plugin.appendConfig = async (config) => {
-	const { cid } = await meta.settings.get('support-forum');
+	const { cid, allowMods } = await meta.settings.get('support-forum');
 
 	return {
 		...config,
-		'support-forum': { cid },
+		'support-forum': { cid, allowMods: allowMods === 'on' },
 	};
 };
 
@@ -144,6 +145,27 @@ plugin.filterTids = async (data) => {
 	return data;
 };
 
+plugin.filterTopics = async (data) => {
+	const { cid } = await meta.settings.get('support-forum');
+	const supportCid = parseInt(cid, 10);
+	if (!supportCid || !Array.isArray(data.topics) || !data.topics.length) return data;
+
+	const allowed = await allowCheck(data.uid);
+	if (allowed) return data;
+
+	const callerUid = parseInt(data.uid, 10);
+	const before = data.topics.length;
+	data.topics = data.topics.filter(topic => (
+		!topic ||
+		parseInt(topic.cid, 10) !== supportCid ||
+		parseInt(topic.uid, 10) === callerUid
+	));
+	if (before !== data.topics.length) {
+		winston.verbose(`[plugins/support-forum] filter:topics.get blocked ${before - data.topics.length} topics for uid ${data.uid}`);
+	}
+	return data;
+};
+
 plugin.filterCategory = async (data) => {
 	const { cid, ownOnly } = await meta.settings.get('support-forum');
 	const allowed = await allowCheck(data.uid, data.cid);
@@ -161,6 +183,74 @@ plugin.filterCategory = async (data) => {
 		return { topics: filtered, uid: data.uid };
 	}
 
+	return data;
+};
+
+function setCounts(category, topics, posts) {
+	category.topic_count = topics;
+	category.post_count = posts;
+	category.totalTopicCount = topics;
+	category.totalPostCount = posts;
+}
+
+async function getOwnCounts(uid, supportCid) {
+	const tids = await db.getSortedSetRange(`cid:${supportCid}:uid:${uid}:tids`, 0, -1);
+	if (!tids.length) return { topics: 0, posts: 0 };
+	const fields = await Topics.getTopicsFields(tids, ['postcount']);
+	const posts = fields.reduce((sum, t) => sum + (parseInt(t && t.postcount, 10) || 0), 0);
+	return { topics: tids.length, posts };
+}
+
+async function adjustCountsForViewer(uid, categories) {
+	const { cid } = await meta.settings.get('support-forum');
+	const supportCid = parseInt(cid, 10);
+	if (!supportCid) return;
+
+	const allowed = await allowCheck(uid);
+	if (allowed) return;
+
+	const callerUid = parseInt(uid, 10);
+	const targets = categories.filter(c => c && parseInt(c.cid, 10) === supportCid);
+	if (!targets.length) return;
+
+	if (!callerUid) {
+		targets.forEach(c => setCounts(c, 0, 0));
+		return;
+	}
+
+	const own = await getOwnCounts(callerUid, supportCid);
+	targets.forEach(c => setCounts(c, own.topics, own.posts));
+}
+
+plugin.hideCounts = async (data) => {
+	if (Array.isArray(data.categoriesData)) {
+		await adjustCountsForViewer(data.uid, data.categoriesData);
+	}
+	return data;
+};
+
+plugin.hideCount = async (data) => {
+	if (data.category) {
+		await adjustCountsForViewer(data.uid, [data.category]);
+	}
+	return data;
+};
+
+function flattenTree(categories, out) {
+	categories.forEach((category) => {
+		if (!category) return;
+		out.push(category);
+		if (Array.isArray(category.children)) flattenTree(category.children, out);
+	});
+}
+
+plugin.hideCountsBuild = async (data) => {
+	const tree = data.templateData && data.templateData.categories;
+	if (Array.isArray(tree)) {
+		const flat = [];
+		flattenTree(tree, flat);
+		await adjustCountsForViewer(data.req.uid || 0, flat);
+	}
 	return data;
 };
 

--- a/plugin.json
+++ b/plugin.json
@@ -14,6 +14,10 @@
 		{ "hook": "filter:categories.recent", "method": "filterPids" },
 		{ "hook": "filter:account.profile.getPids", "method": "filterPids" },
 		{ "hook": "filter:category.topics.get", "method": "filterCategory" },
+		{ "hook": "filter:helpers.getVisibleCategories", "method": "hideCounts" },
+		{ "hook": "filter:category.get", "method": "hideCount" },
+		{ "hook": "filter:categories.build", "method": "hideCountsBuild" },
+		{ "hook": "filter:topics.get", "method": "filterTopics" },
 		{ "hook": "static:app.load", "method": "init" },
 		{ "hook": "filter:admin.header.build", "method": "addAdminNavigation" },
 		{ "hook": "filter:notification.push", "method": "blockUserFollowNotifications" }

--- a/static/lib/main.js
+++ b/static/lib/main.js
@@ -1,9 +1,23 @@
 'use strict';
 
 require(['hooks'], (hooks) => {
+	const cfg = config['support-forum'];
+	const supportCid = parseInt(cfg.cid, 10);
+	const isGuest = !app.user.uid;
+
+	if (supportCid && isGuest) {
+		const style = document.createElement('style');
+		style.textContent = `
+			li.category-${supportCid} .stats,
+			li.category-${supportCid} .teaser { visibility: hidden !important; }
+			body.page-category-${supportCid} .stats { display: none !important; }
+		`;
+		document.head.appendChild(style);
+	}
+
 	hooks.on('filter:topicList.onNewTopic', ({ topic, preventAlert }) => {
 		const { cid } = topic;
-		if (cid === parseInt(config['support-forum'].cid, 10)) {
+		if (cid === supportCid) {
 			preventAlert = true;
 		}
 

--- a/test/index.js
+++ b/test/index.js
@@ -318,11 +318,192 @@ describe('nodebb-plugin-support-forum', () => {
 		});
 	});
 
+	describe('hideCounts (filter:helpers.getVisibleCategories)', () => {
+		const sampleData = () => ({
+			categoriesData: [
+				{ cid: supportCid, topic_count: 99, post_count: 99, totalTopicCount: 99, totalPostCount: 99 },
+				{ cid: otherCid, topic_count: 3, post_count: 4, totalTopicCount: 3, totalPostCount: 4 },
+			],
+		});
+
+		const assertSupport = (cat, topics, posts) => {
+			assert.strictEqual(cat.topic_count, topics, 'topic_count');
+			assert.strictEqual(cat.post_count, posts, 'post_count');
+			assert.strictEqual(cat.totalTopicCount, topics, 'totalTopicCount');
+			assert.strictEqual(cat.totalPostCount, posts, 'totalPostCount');
+		};
+
+		it('zeros all count fields on the support category for guests', async () => {
+			const data = sampleData();
+			data.uid = 0;
+			const result = await plugin.hideCounts(data);
+			assertSupport(result.categoriesData[0], 0, 0);
+		});
+
+		it('shows the author their own topic and post counts', async () => {
+			const data = sampleData();
+			data.uid = authorUid;
+			const result = await plugin.hideCounts(data);
+			assertSupport(result.categoriesData[0], 1, 1);
+		});
+
+		it('shows zeros to a logged-in user with no support topics of their own', async () => {
+			const data = sampleData();
+			data.uid = otherUid;
+			const result = await plugin.hideCounts(data);
+			assertSupport(result.categoriesData[0], 0, 0);
+		});
+
+		it('never touches counts of non-support categories', async () => {
+			const data = sampleData();
+			data.uid = otherUid;
+			const result = await plugin.hideCounts(data);
+			assert.deepStrictEqual(result.categoriesData[1], {
+				cid: otherCid, topic_count: 3, post_count: 4, totalTopicCount: 3, totalPostCount: 4,
+			});
+		});
+
+		it('keeps real counts visible to administrators', async () => {
+			const data = sampleData();
+			data.uid = adminUid;
+			const result = await plugin.hideCounts(data);
+			assertSupport(result.categoriesData[0], 99, 99);
+		});
+
+		it('falls back to own counts for global moderators when allowMods=off', async () => {
+			const data = sampleData();
+			data.uid = gmodUid;
+			const result = await plugin.hideCounts(data);
+			assertSupport(result.categoriesData[0], 0, 0);
+		});
+
+		describe('with allowMods=on', () => {
+			before(async () => { await setPluginConfig({ allowMods: 'on' }); });
+			after(async () => { await setPluginConfig(); });
+
+			it('reveals real counts to global moderators', async () => {
+				const data = sampleData();
+				data.uid = gmodUid;
+				const result = await plugin.hideCounts(data);
+				assertSupport(result.categoriesData[0], 99, 99);
+			});
+
+			it('reveals real counts to category moderators', async () => {
+				const data = sampleData();
+				data.uid = modUid;
+				const result = await plugin.hideCounts(data);
+				assertSupport(result.categoriesData[0], 99, 99);
+			});
+		});
+	});
+
+	describe('hideCountsBuild (filter:categories.build, walks the tree)', () => {
+		const sampleData = uid => ({
+			req: { uid },
+			templateData: {
+				categories: [
+					{
+						cid: 999,
+						isSection: true,
+						children: [
+							{ cid: supportCid, topic_count: 99, post_count: 99, totalTopicCount: 99, totalPostCount: 99 },
+							{ cid: otherCid, topic_count: 3, post_count: 4, totalTopicCount: 3, totalPostCount: 4 },
+						],
+					},
+				],
+			},
+		});
+
+		it('adjusts counts for support category nested under a section', async () => {
+			const result = await plugin.hideCountsBuild(sampleData(authorUid));
+			const supportInTree = result.templateData.categories[0].children[0];
+			assert.strictEqual(supportInTree.topic_count, 1);
+			assert.strictEqual(supportInTree.totalPostCount, 1);
+		});
+
+		it('zeros support counts for guests in the tree', async () => {
+			const result = await plugin.hideCountsBuild(sampleData(0));
+			const supportInTree = result.templateData.categories[0].children[0];
+			assert.strictEqual(supportInTree.topic_count, 0);
+			assert.strictEqual(supportInTree.totalPostCount, 0);
+		});
+
+		it('leaves admins\' tree untouched', async () => {
+			const result = await plugin.hideCountsBuild(sampleData(adminUid));
+			const supportInTree = result.templateData.categories[0].children[0];
+			assert.strictEqual(supportInTree.topic_count, 99);
+		});
+	});
+
+	describe('hideCount (filter:category.get, single category)', () => {
+		const sampleData = uid => ({
+			uid,
+			category: { cid: supportCid, topic_count: 99, post_count: 99, totalTopicCount: 99, totalPostCount: 99 },
+		});
+
+		it('returns own counts for the author', async () => {
+			const result = await plugin.hideCount(sampleData(authorUid));
+			assert.strictEqual(result.category.topic_count, 1);
+			assert.strictEqual(result.category.totalPostCount, 1);
+		});
+
+		it('returns zeros for guests', async () => {
+			const result = await plugin.hideCount(sampleData(0));
+			assert.strictEqual(result.category.topic_count, 0);
+			assert.strictEqual(result.category.totalPostCount, 0);
+		});
+
+		it('keeps real counts for admins', async () => {
+			const result = await plugin.hideCount(sampleData(adminUid));
+			assert.strictEqual(result.category.topic_count, 99);
+		});
+
+		it('passes through when category is not the support category', async () => {
+			const data = { uid: otherUid, category: { cid: otherCid, topic_count: 3, post_count: 4 } };
+			const result = await plugin.hideCount(data);
+			assert.strictEqual(result.category.topic_count, 3);
+			assert.strictEqual(result.category.post_count, 4);
+		});
+	});
+
+	describe('filterTopics (filter:topics.get, backstops RSS)', () => {
+		const sampleTopics = () => [
+			{ tid: supportTid, cid: supportCid, uid: authorUid },
+			{ tid: otherTid, cid: otherCid, uid: authorUid },
+		];
+
+		it('hides another user\'s support topics from a regular viewer', async () => {
+			const result = await plugin.filterTopics({ uid: otherUid, topics: sampleTopics() });
+			assert.deepStrictEqual(result.topics.map(t => t.tid), [otherTid]);
+		});
+
+		it('keeps own support topics for the author', async () => {
+			const result = await plugin.filterTopics({ uid: authorUid, topics: sampleTopics() });
+			assert.deepStrictEqual(result.topics.map(t => t.tid), [supportTid, otherTid]);
+		});
+
+		it('keeps all topics for administrators', async () => {
+			const result = await plugin.filterTopics({ uid: adminUid, topics: sampleTopics() });
+			assert.deepStrictEqual(result.topics.map(t => t.tid), [supportTid, otherTid]);
+		});
+
+		it('hides all support topics from guests', async () => {
+			const result = await plugin.filterTopics({ uid: 0, topics: sampleTopics() });
+			assert.deepStrictEqual(result.topics.map(t => t.tid), [otherTid]);
+		});
+
+		it('does not modify topics when the input is empty', async () => {
+			const result = await plugin.filterTopics({ uid: otherUid, topics: [] });
+			assert.deepStrictEqual(result.topics, []);
+		});
+	});
+
 	describe('appendConfig', () => {
 		it('exposes the support-forum cid to the frontend config', async () => {
 			const result = await plugin.appendConfig({ someExisting: 'value' });
 			assert.strictEqual(result.someExisting, 'value');
 			assert.strictEqual(parseInt(result['support-forum'].cid, 10), parseInt(supportCid, 10));
+			assert.strictEqual(result['support-forum'].allowMods, false);
 		});
 	});
 });


### PR DESCRIPTION
Replaces blanket leak of support topic/post totals with per-viewer
counts (admins keep real totals, logged-in users get their own,
guests get zeros + CSS hide), and hooks `filter:topics.get` to backstop
paths that bypass `filter:privileges.topics.filter` (notably the RSS feed).